### PR TITLE
fix virsh scripts to filter by VM state

### DIFF
--- a/virsh-shutdown-all.sh
+++ b/virsh-shutdown-all.sh
@@ -5,4 +5,4 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-virsh list --all | grep 'running' | awk '{print $2}' | xargs --no-run-if-empty -t -I {} virsh shutdown {}
+virsh list --state-running --name | xargs --no-run-if-empty -t -I {} virsh shutdown {}

--- a/virsh-start-all.sh
+++ b/virsh-start-all.sh
@@ -5,6 +5,6 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-for vm in $(virsh list --all --name); do
+for vm in $(virsh list --state-shutoff --name); do
   virsh start "$vm"
 done


### PR DESCRIPTION
## Summary
- `virsh-shutdown-all.sh`: replace fragile grep+awk pipeline with `--state-running --name`
- `virsh-start-all.sh`: use `--state-shutoff --name` instead of `--all` to skip already-running VMs (fixes "Domain is already active" error that caused the loop to abort early)

## Test plan
- [ ] Run `virsh-start-all.sh` with mix of running and stopped VMs — should only start stopped ones
- [ ] Run `virsh-shutdown-all.sh` — should shut down all running VMs