### PR TITLE
Add GitHub workflows and shellcheck validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run precommit checks
+        run: make precommit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,39 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- CI workflow with shellcheck validation
+- Claude Code workflow for @claude mentions in PRs/issues
+- Makefile with test/check/precommit targets for shellcheck
+- CHANGELOG.md for tracking changes

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+test: check
+
+check:
+	shellcheck -S error *.sh
+
+precommit: check
+
+.PHONY: test check precommit


### PR DESCRIPTION
## Summary
- CI workflow with shellcheck validation (errors only)
- Claude Code workflow for @claude mentions
- Makefile with test/check/precommit targets
- CHANGELOG.md for tracking changes

## Changes
- `.github/workflows/ci.yml` - shellcheck on PRs (errors only)
- `.github/workflows/claude.yml` - @claude trigger pattern
- `Makefile` - test/check/precommit targets
- `CHANGELOG.md` - standard changelog format

## Configuration
- `shellcheck -S error` - fail only on errors, not warnings/style
- Warnings still shown but don't block CI
- Can tighten to `-S warning` later after cleanup