### PR TITLE
virsh-start-all: exclude nuke-workspace and nuke-boss

### DIFF
--- a/virsh-start-all.sh
+++ b/virsh-start-all.sh
@@ -5,6 +5,19 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+EXCLUDE=(nuke-workspace nuke-boss)
+
 for vm in $(virsh list --state-shutoff --name); do
+  skip=0
+  for ex in "${EXCLUDE[@]}"; do
+    if [[ "$vm" == "$ex" ]]; then
+      skip=1
+      break
+    fi
+  done
+  if [[ $skip -eq 1 ]]; then
+    echo "skip $vm (excluded)"
+    continue
+  fi
   virsh start "$vm"
 done


### PR DESCRIPTION
## Summary

- Skip `nuke-workspace` and `nuke-boss` from `virsh-start-all.sh` auto-start
- Frees ~20 GB of host RAM on `nuke` hypervisor

## Why

Host is currently over-committed: VM allocations sum to 146 GB on a 125 GB host. On 2026-06-22 the kernel OOM-killed `nuke-k3s-dev-0` (24 GB VM) → dev cluster lost its only worker for 2 days, stuck Terminating pods, `VaultObsidianOpenclawPullFailing` alerts.

Excluding the two non-critical VMs from auto-start brings allocation back under host RAM. They can still be started manually when needed.

## Test plan

- [ ] Run on `nuke` with both excluded VMs in `--state-shutoff` and confirm they are skipped with "skip $vm (excluded)" output
- [ ] Confirm other shutoff VMs still start